### PR TITLE
cmake: link ceph_test_cephd_api_misc with Boost::context and coroutine

### DIFF
--- a/src/test/libcephd/CMakeLists.txt
+++ b/src/test/libcephd/CMakeLists.txt
@@ -17,6 +17,11 @@ set_target_properties(ceph_test_cephd_api_misc PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(ceph_test_cephd_api_misc
 	cephd global ${UNITTEST_LIBS} cephdtest z snappy ceph_zstd)
+if(WITH_RADOSGW_BEAST_FRONTEND)
+  target_link_libraries(ceph_test_cephd_api_misc LINK_PRIVATE
+    ${Boost_COROUTINE_LIBRARY}
+    ${Boost_CONTEXT_LIBRARY})
+endif()
 
 install(TARGETS
   ceph_test_cephd_api_misc


### PR DESCRIPTION
Fixes the following build failure:

```
Scanning dependencies of target ceph_test_cephd_api_misc
[100%] Building CXX object src/test/libcephd/CMakeFiles/ceph_test_cephd_api_misc.dir/misc.cc.o
[100%] Linking CXX executable ../../../bin/ceph_test_cephd_api_misc
../../../boost/lib/libboost_coroutine.a(coroutine_context.o): In function oost::coroutines::detail::coroutine_context::coroutine_context(void (*)(boost::context::detail::transfer_t), boost::coroutines::detail::preallocated const&)':
coroutine_context.cpp:(.text+0x59): undefined reference to ake_fcontext'
../../../boost/lib/libboost_coroutine.a(coroutine_context.o): In function oost::coroutines::detail::coroutine_context::jump(boost::coroutines::detail::coroutine_context&, void*)':
coroutine_context.cpp:(.text+0xe5): undefined reference to ump_fcontext'
collect2: error: ld returned 1 exit status
src/test/libcephd/CMakeFiles/ceph_test_cephd_api_misc.dir/build.make:154: recipe for target 'bin/ceph_test_cephd_api_misc' failed
make[2]: *** [bin/ceph_test_cephd_api_misc] Error 1
CMakeFiles/Makefile2:14296: recipe for target 'src/test/libcephd/CMakeFiles/ceph_test_cephd_api_misc.dir/all' failed
make[1]: *** [src/test/libcephd/CMakeFiles/ceph_test_cephd_api_misc.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[100%] Linking CXX executable ../bin/ceph-dencoder
[100%] Built target ceph-dencoder
Makefile:138: recipe for target 'all' failed
make: *** [all] Error 2
```

Signed-off-by: Nathan Cutler <ncutler@suse.com>