### PR TITLE
drop explicit boost link for ceph_test_cephd_api_misc

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -265,9 +265,4 @@ if(WITH_EMBEDDED)
   if(WITH_RADOSGW_FCGI_FRONTEND) 
     target_link_libraries(cephd_rgw ${FCGI_LIBRARY})
   endif()
-  if(WITH_RADOSGW_BEAST_FRONTEND)
-    target_link_libraries(cephd_rgw LINK_PRIVATE
-      ${Boost_COROUTINE_LIBRARY}
-      ${Boost_CONTEXT_LIBRARY})
-  endif()
 endif()


### PR DESCRIPTION
```
$ make -j 8
...
Scanning dependencies of target cephd
[100%] Building C object src/libcephd/CMakeFiles/cephd.dir/cephd_dummy.c.o
[100%] Linking CXX static library ../../lib/libcephd.a
[100%] Linking CXX executable ../../bin/ceph_test_rgw_token
[100%] Built target ceph_test_rgw_token
[100%] Linking CXX executable ../../bin/ceph_test_librgw_file_aw
[100%] Built target ceph_test_librgw_file_aw
[100%] Linking CXX executable ../../bin/radosgw
[100%] Linking CXX executable ../../bin/ceph_test_librgw_file_nfsns
[100%] Built target ceph_test_librgw_file_nfsns
[100%] Built target cephd
Scanning dependencies of target ceph_test_cephd_api_misc
[100%] Building CXX object src/test/libcephd/CMakeFiles/ceph_test_cephd_api_misc.dir/misc.cc.o
[100%] Built target radosgw
[100%] Linking CXX executable ../../../bin/ceph_test_cephd_api_misc
[100%] Linking CXX executable ../../bin/radosgw-admin
[100%] Built target radosgw-admin
[100%] Built target ceph_test_cephd_api_misc
[100%] Linking CXX executable ../bin/ceph-dencoder
[100%] Built target ceph-dencoder
$
```